### PR TITLE
decoupled json decode and allow for errors

### DIFF
--- a/channelfinder/ChannelFinderClient.py
+++ b/channelfinder/ChannelFinderClient.py
@@ -216,9 +216,9 @@ class ChannelFinderClient(object):
     def __decode_json(self, raw_string):
         try:
             data = loads(raw_string)
-        except:
-            logger.warn("JSON returned is not valid.")
-            return None
+        except Exception as e:
+            msg = "{} : {}".format(e, repr(raw_string._content))
+            raise RuntimeError(msg)
 
     def find(self, **kwds):
         '''

--- a/channelfinder/_conf.py
+++ b/channelfinder/_conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 Internal module
 
@@ -13,16 +14,21 @@ password=MyPassword
 """
 
 def __loadConfig():
+    import logging
     import os.path
     import ConfigParser
-    dflt={'BaseURL':'http://localhost:8080/ChannelFinder'
-        }
-    cf=ConfigParser.SafeConfigParser(defaults=dflt)
-#    print os.path.normpath(os.path.expanduser('~/channelfinderapi.conf'))
-    cf.read([
-        '/etc/channelfinderapi.conf',
-        os.path.expanduser('~/channelfinderapi.conf'),
-        'channelfinderapi.conf'
-    ])
+
+    log = logging.getLogger(__name__)
+
+    dflt = {'BaseURL':'http://localhost:8080/ChannelFinder'}
+
+    cf = ConfigParser.SafeConfigParser(defaults=dflt)
+    cf.read(['/etc/channelfinderapi.conf',
+             os.path.expanduser('~/channelfinderapi.conf'),
+             'channelfinderapi.conf'
+             ])
+
+    logging.info("URL:%s" % cf.get('DEFAULT', 'BaseURL'))
     return cf
-_conf=__loadConfig()
+
+_conf = __loadConfig()


### PR DESCRIPTION
If a CF database doesn't have any properties yet, a call to findByArgs returns an invalid json.
This is a quick and dirty fix for now, to decode the json separately and return None if it fails.

rec_sync's recceiver component  does this and is causing exceptions for me. It's reasonable to not
have any DB entries yet when first building a CF DB and to use rec_sync to help build entries.